### PR TITLE
Modify rviz_carla_plugin/CMakeLists.txt for a successful build with l…

### DIFF
--- a/rviz_carla_plugin/CMakeLists.txt
+++ b/rviz_carla_plugin/CMakeLists.txt
@@ -1,10 +1,21 @@
 cmake_minimum_required(VERSION 3.3)
 project(rviz_carla_plugin)
 
+find_package(PkgConfig)
+pkg_check_modules(log4cxx liblog4cxx)
+
 set(CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 14)
+
+if(log4cxx_VERSION VERSION_GREATER_EQUAL "0.12.0")
+  message("Setting CXX standard to 17")
+  set(CMAKE_CXX_STANDARD 17)
+else()
+  message("Setting CXX standard to 14")
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 find_package(ros_environment REQUIRED)
+
 set(ROS_VERSION $ENV{ROS_VERSION})
 
 if(${ROS_VERSION} EQUAL 1)


### PR DESCRIPTION
[Starting from](https://logging.apache.org/log4cxx/1.4.0/changelog.html#rel_12_0) `log4cxx` version 0.12.0, it started using `std::shared_ptr` as the smart pointer implementation. On systems (i.e Ubuntu22) that have that version or greater, the build fails with `/usr/include/log4cxx/boost-std-configuration.h:10:18: error: 'shared_mutex' in namespace 'std' dose not name a type`.

This change will use cmake cxx standard 17 to build the `rviz_carla_plugin` istead of cmake cxx standard 14 if it detects log4cxx version greater than or equal to 0.12.0.